### PR TITLE
GIT init project as post hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python
 import os
+import subprocess
+
 
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
 
 
 def remove_file(filepath):
     os.remove(os.path.join(PROJECT_DIRECTORY, filepath))
+
+
+def git_init():
+    subprocess.call(["git", "init"])
 
 
 if __name__ == "__main__":
@@ -15,3 +21,5 @@ if __name__ == "__main__":
 
     if "{{ cookiecutter.github_action_tag_triggered }}" != "y":
         remove_file(".github/workflows/triggered_by_tag.yml")
+
+    git_init()


### PR DESCRIPTION
To use setuptools_scm the git init is mandatory