### PR TITLE
_version.py excluded from coverage and better lint

### DIFF
--- a/{{cookiecutter.project_name_kebab}}/Makefile
+++ b/{{cookiecutter.project_name_kebab}}/Makefile
@@ -51,7 +51,7 @@ lint:
 {%- if cookiecutter.use_flake8 == 'y' %}
 	flake8 {{ cookiecutter.project_name_snake }} tests
 {%- endif %}
-	find . -type f -name "*.py" | xargs pylint
+	pylint {{ cookiecutter.project_name_snake }} tests setup.py
 
 test: ## run tests quickly with the default Python
 	pytest
@@ -59,7 +59,7 @@ test: ## run tests quickly with the default Python
 {%- if cookiecutter.use_coverage == 'y' %}
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source {{ cookiecutter.project_name_snake }} -m pytest
-	coverage report -m
+	coverage report -m --omit={{ cookiecutter.project_name_snake }}/_version.py
 	coverage html
 
 coverage-web: coverage ## check code coverage and open report in web browser


### PR DESCRIPTION
_version.py should not be checked by the coverage tool 'cause is not
part of the source code (it's in the .gitignore and existing only in
case of a build).
Pylint should check explicit folders to avoid problems with local
virtualenvs.