### PR TITLE
Add targets to .PHONY

### DIFF
--- a/{{cookiecutter.project_name_kebab}}/Makefile
+++ b/{{cookiecutter.project_name_kebab}}/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build format help
+.PHONY: clean clean-test clean-pyc clean-build lint test coverage format help
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT


### PR DESCRIPTION
In case of files named as test, lint or coverage, the target with same
name won't be executed. Adding targets to .PHONY should fix the problem.