### PR TITLE
Line length fix in template

### DIFF
--- a/{{cookiecutter.project_name_kebab}}/.pylintrc
+++ b/{{cookiecutter.project_name_kebab}}/.pylintrc
@@ -1,5 +1,5 @@
 [FORMAT]
-max-line-length = 88
+max-line-length = 100
 
 [SIMILARITIES]
 min-similarity-lines=4

--- a/{{cookiecutter.project_name_kebab}}/setup.cfg
+++ b/{{cookiecutter.project_name_kebab}}/setup.cfg
@@ -15,5 +15,5 @@ exclude =
     docs,
     build,
     dist
-max-line-length = 88
+max-line-length = 100
 {%- endif %}


### PR DESCRIPTION
Previous PR changed max-line-length in the cookie-cutter project itself
but did not change the template files that are the ones used to generate
new projects.