### PR TITLE
Encoding for open

### DIFF
--- a/{{cookiecutter.project_name_kebab}}/Makefile
+++ b/{{cookiecutter.project_name_kebab}}/Makefile
@@ -49,7 +49,7 @@ clean-test: ## remove test and coverage artifacts
 
 lint:  ## use the default linter pylint and the optional flake8 to verify the code style
 {%- if cookiecutter.use_flake8 == 'y' %}
-	flake8 {{ cookiecutter.project_name_snake }} tests
+	flake8 {{ cookiecutter.project_name_snake }} tests setup.py
 {%- endif %}
 	pylint {{ cookiecutter.project_name_snake }} tests setup.py
 

--- a/{{cookiecutter.project_name_kebab}}/setup.py
+++ b/{{cookiecutter.project_name_kebab}}/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 MINIMAL_REQUIREMENTS = []
 
-with open("README.md") as readme_file:
+with open("README.md", encoding="UTF-8") as readme_file:
     readme = readme_file.read()
 
 setup(


### PR DESCRIPTION
With recent updates to the linter, in py3 the encodig for the open
method should be provided.
In this case the setup.py file was missing that parameter.