### PR TITLE
Remove 'data_files' from 'Setup.py'

### DIFF
--- a/{{cookiecutter.project_name_kebab}}/setup.py
+++ b/{{cookiecutter.project_name_kebab}}/setup.py
@@ -18,7 +18,6 @@ setup(
     license="{{ cookiecutter.license }}",
     url="https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name_kebab }}",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    data_files=[("", ["LICENSE"])],
     install_requires=MINIMAL_REQUIREMENTS,
     zip_safe=False,
     keywords=[


### PR DESCRIPTION
In this PR has been removed the field 'data_files' from 'Setup.py'
because the file 'LICENSE' is  automatically added in packaging

Jira ref: [PROC-105]

[PROC-105]: https://tre-altamira.atlassian.net/browse/PROC-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ